### PR TITLE
Serve swagger ui with a CDN

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -2,7 +2,21 @@
 
 ## How to use
 
-Follow instructions in main `README.md` to generate the backend (if needed).
+Follow the `kubo` installation instructions for your operating system located [here](https://docs.ipfs.tech/install/command-line/#install-official-binary-distributions).
+
+If you haven't used IPFS so far, initialize the IPFS repository using the following command:
+
+`ipfs init`
+
+If you had used IPFS an already have an IPFS repository in place, either (re)move it from ~/.ipfs or make sure to export IPFS_PATH before running the ipfs init command, e.g.:
+
+```
+export IPFS_PATH=~/.ipfs-sector
+ipfs init
+```
+
+Follow instructions in main `README.md` to generate the backend server files (if needed).
+Then run the following commands to build the backend.
 
 - Download the Go modules: `go mod download`
 - Start the server: `go run main.go`

--- a/backend/main.go
+++ b/backend/main.go
@@ -4,6 +4,7 @@ import (
 	v1 "app/internal/api/v1"
 	"app/internal/middleware"
 	"context"
+	"embed"
 	"encoding/json"
 	"flag"
 	"log"
@@ -14,6 +15,9 @@ import (
 	"github.com/gorilla/mux"
 	oapimiddleware "github.com/oapi-codegen/nethttp-middleware"
 )
+
+//go:embed swagger-ui.html
+var swaggerUI embed.FS
 
 func main() {
 	port := flag.String("port", "3000", "Port for HTTP server")
@@ -41,6 +45,17 @@ func main() {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(swaggerV1)
+	})
+
+	// Serve the Swagger UI using a CDN
+	r.HandleFunc("/v1/swagger-ui/", func(w http.ResponseWriter, r *http.Request) {
+		data, err := swaggerUI.ReadFile("swagger-ui.html")
+		if err != nil {
+			http.Error(w, "swagger.html not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(data))
 	})
 
 	// Subrouter to validate requests to the /v1/api/

--- a/backend/swagger-ui.html
+++ b/backend/swagger-ui.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Swagger UI</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.12.0/swagger-ui.min.css">
+</head>
+
+<body>
+    <div id="swagger-ui"></div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.12.0/swagger-ui-bundle.min.js"></script>
+    <script>
+        window.onload = function () {
+            const ui = SwaggerUIBundle({
+                url: "/v1/swagger.json",
+                dom_id: "#swagger-ui",
+            });
+        };
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
# Issue
Closes #31 

# Description
Utilizing a CDN to serve the swagger UI once again. The swagger UI will utilize the generated swagger definition from the oapi-codegen, and uses a cloudflare hosted swagger ui bundle to serve the UI. 

# Type Of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update
- [ ] This change requires a documentation update

# Test Steps
Runs locally in my machine.

# Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published downstream

## Formatting
Please use markdown in your pull request message. A useful summary of commands can be found [here](https://guides.github.com/pdfs/markdown-cheatsheet-online.pdf).